### PR TITLE
Update npm install for better default behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "node-pre-gyp install"
+    "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This change will add the default behaviour of falling back to building when installing formide-drivers as dependency in another project. Fixes #1.